### PR TITLE
Add windows named pipeline support

### DIFF
--- a/listener_others.go
+++ b/listener_others.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package dockerapiproxy
+
+import "net"
+
+func getListener(proto, address string) (net.Listener, error) {
+	return net.Listen(proto, address)
+}

--- a/listener_windows.go
+++ b/listener_windows.go
@@ -1,0 +1,19 @@
+// +build windows
+
+package dockerapiproxy
+
+import (
+	"net"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func getListener(proto, address string) (net.Listener, error) {
+	npipeConfig := &winio.PipeConfig{
+		SecurityDescriptor: "D:P(A;;GA;;;BA)(A;;GA;;;SY)",
+		MessageMode:        true,  // Use message mode so that CloseWrite() is supported
+		InputBufferSize:    65536, // Use 64KB buffers to improve performance
+		OutputBufferSize:   65536,
+	}
+	return winio.ListenPipe(address, npipeConfig)
+}

--- a/server.go
+++ b/server.go
@@ -54,7 +54,7 @@ func (p *Proxy) getSocket(url string) (net.Listener, error) {
 		os.Remove(address)
 	}
 
-	l, err := net.Listen(proto, address)
+	l, err := getListener(proto, address)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Related issue https://github.com/rancher/rancher/issues/7262
The `unix` proto is not supported in Windows.
We need to use named pipeline in Windows instead.